### PR TITLE
Fixing the way traverse is implemented for Option.None.

### DIFF
--- a/src/option.js
+++ b/src/option.js
@@ -96,13 +96,12 @@ Option.prototype.sequence = function() {
     }, x);
 };
 Option.prototype.traverse = function(f, p) {
-    return this.cata({
+    var env = this;
+    return env.cata({
         Some: function(x) {
             return p.of(f(x));
         },
-        None: function() {
-            return p.of(Option.None);
-        }
+        None: constant(env)
     });
 };
 

--- a/test/option.js
+++ b/test/option.js
@@ -125,7 +125,7 @@ exports.option = {
 
     'when testing traverse with None should return correct value': λ.check(
         function(a) {
-            return a.traverse(identity, Identity).x === Option.None;
+            return a.traverse(identity, Identity) === Option.None;
         },
         [λ.noneOf()]
     ),


### PR DESCRIPTION
Option traverse is wrongly implemented.
- For Option.None it shouldn't traverse.
